### PR TITLE
fix software-keyboard-sample to use g.Sprite instead of g.Pane

### DIFF
--- a/contents/demo/templates/software-keyboard-sample/script/Keyboard.js
+++ b/contents/demo/templates/software-keyboard-sample/script/Keyboard.js
@@ -153,13 +153,13 @@ class Keyboard extends g.E {
         });
         this.kanaKey.append(semiVoicedKey);
         const backSpaceKeyAsset = this.sceneAssets.getImage("/image/backSpaceKey.png");
-        this.backSpaceKey = new g.Pane({
+        this.backSpaceKey = new g.Sprite({
             scene: this.scene,
             width: backSpaceKeyAsset.width,
             height: backSpaceKeyAsset.height,
             x: g.game.width - 28 - backSpaceKeyAsset.width,
             y: this.inputtingLabelBack.y + (this.inputtingLabelBack.height - backSpaceKeyAsset.height) / 2,
-            backgroundImage: backSpaceKeyAsset,
+            src: backSpaceKeyAsset,
             touchable: true
         });
         this.backSpaceKey.onPointDown.add(() => {

--- a/contents/demo/templates/software-keyboard-sample/script/MultiKeyboard.js
+++ b/contents/demo/templates/software-keyboard-sample/script/MultiKeyboard.js
@@ -78,13 +78,13 @@ class MultiKeyboard extends Keyboard_1.Keyboard {
             this.symKey.append(key);
         }
         const convKanaAsset = this.scene.asset.getImage("/image/toKanaLetters.png");
-        this.convKana = new g.Pane({
+        this.convKana = new g.Sprite({
             scene: this.scene,
             width: convKanaAsset.width,
             height: convKanaAsset.height,
             x: def.convX[0],
             y: def.convY,
-            backgroundImage: convKanaAsset,
+            src: convKanaAsset,
             touchable: true,
             hidden: true
         });
@@ -100,13 +100,13 @@ class MultiKeyboard extends Keyboard_1.Keyboard {
         });
         this.common.append(this.convKana);
         const convAlphaAsset = this.scene.asset.getImage("/image/toAlphaLetters.png");
-        this.convAlpha = new g.Pane({
+        this.convAlpha = new g.Sprite({
             scene: this.scene,
             width: convAlphaAsset.width,
             height: convAlphaAsset.height,
             x: def.convX[0],
             y: def.convY,
-            backgroundImage: convAlphaAsset,
+            src: convAlphaAsset,
             touchable: true
         });
         this.convAlpha.onPointDown.add(() => {
@@ -119,13 +119,13 @@ class MultiKeyboard extends Keyboard_1.Keyboard {
         });
         this.common.append(this.convAlpha);
         const convSymAsset = this.scene.asset.getImage("/image/toSymLetters.png");
-        this.convSym = new g.Pane({
+        this.convSym = new g.Sprite({
             scene: this.scene,
             width: convSymAsset.width,
             height: convSymAsset.height,
             x: def.convX[1],
             y: def.convY,
-            backgroundImage: convSymAsset,
+            src: convSymAsset,
             touchable: true
         });
         this.convSym.onPointDown.add(() => {

--- a/contents/demo/templates/software-keyboard-sample/script/main.js
+++ b/contents/demo/templates/software-keyboard-sample/script/main.js
@@ -71,26 +71,26 @@ function main() {
         let state = 1 /* OFF */;
         const openAsset = scene.asset.getImage("/image/open.png");
         const closeAsset = scene.asset.getImage("/image/close.png");
-        const keyboardButton = new g.Pane({
+        const keyboardButton = new g.Sprite({
             scene: scene,
             width: openAsset.width,
             height: openAsset.height,
             x: g.game.width / 2 - openAsset.width / 2,
             y: 610,
-            backgroundImage: openAsset,
+            src: openAsset,
             touchable: true
         });
         keyboardButton.onPointDown.add(() => {
             switch (state) {
                 case 1 /* OFF */:
-                    keyboardButton.backgroundImage = closeAsset;
+                    keyboardButton.src = closeAsset;
                     timeline.create(keyboard).moveTo(0, 0, 150);
                     state = 0 /* ON */;
                     break;
                 case 0 /* ON */:
                     name.text = keyboard.text;
                     name.invalidate();
-                    keyboardButton.backgroundImage = openAsset;
+                    keyboardButton.src = openAsset;
                     timeline.create(keyboard).moveTo(0, g.game.height, 150);
                     state = 1 /* OFF */;
                     break;


### PR DESCRIPTION
### やったこと
- サンプルコンテンツのソフトウェアキーボードで、`g.Pane`である必要性が薄い部分で`g.Sprite`を使うように修正しました。
  - [公式ページ](https://akashic-games.github.io/tips/acceleration-tips.html#pane)でも`g.Pane`の利用箇所を減らすことを推奨しているので、それに準拠するようにしました