### PR TITLE
chore: set min-release-age

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: ">=24.14.1" # npm@11.11.0 (min-release-age が使える) が同梱される下限
           cache: npm
       - name: Install project
         run: |

--- a/.github/workflows/reftest.yml
+++ b/.github/workflows/reftest.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: ">=24.14.1" # npm@11.11.0 (min-release-age が使える) が同梱される下限
 
       - name: Setup locale for Japanese
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: ">=24.14.1" # npm@11.11.0 (min-release-age が使える) が同梱される下限
           cache: npm
       - name: Install project
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [18.x, 20.x]
+        node: [">=24.14.1"] # npm@11.11.0 (min-release-age が使える) が同梱される下限以降
     steps:
       - name: Checkout code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/update-reftest-expected-images.yml
+++ b/.github/workflows/update-reftest-expected-images.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: ">=24.14.1" # npm@11.11.0 (min-release-age が使える) が同梱される下限
 
       - name: Setup locale for Japanese
         run: |

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+ignore-scripts=true
+min-release-age=7
+

--- a/package.json
+++ b/package.json
@@ -13,6 +13,13 @@
     "test": "run-s test:*",
     "test:format": "prettier . --check"
   },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "11.11.0",
+      "onFail": "error"
+    }
+  },
   "devDependencies": {
     "@types/archiver": "^6.0.2",
     "@types/micromatch": "^4.0.9",


### PR DESCRIPTION
min-release-age を設定し、それが使える npm のバージョンを保証するようにします。
別でレビュー済みのためセルフマージします。
